### PR TITLE
Optimize for unified v10

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This package is ESM only: Node 12+ is needed to use it and it must be imported i
 
 
 ```typescript
-import unified from 'unified'
+import { unified } from 'unified'
 import rehyper from 'rehyper'
 import remarkParse from 'remark-parse'
 import remarkRehype from 'remark-rehype'

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "ttypescript": "^1.5.12",
     "typescript": "^4.2.2",
     "typescript-transform-paths": "^2.2.3",
-    "unified": "9.2.1"
+    "unified": "^10.1.2"
   },
   "dependencies": {
     "@types/node": "^14.14.31",
@@ -93,7 +93,7 @@
     "unist-util-visit": "^3.1.0"
   },
   "peerDependencies": {
-    "unified": "^9 || ^10"
+    "unified": "^10"
   },
   "types": "lib/index.d.ts"
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import Prism from 'prismjs'
 import parse from 'rehype-parse'
-import unified from 'unified'
+import unifiedTypes, { unified } from 'unified'
 import * as mdast from 'mdast'
 import * as hast from 'hast'
 import { Node } from 'unist'
@@ -56,7 +56,7 @@ interface Options {
   )[]
 }
 
-const rehypePrism: unified.Plugin<[Options?]> = (options?: Options) => {
+const rehypePrism: unifiedTypes.Plugin<[Options?]> = (options?: Options) => {
   if (options && options.plugins) {
     for (const plugin of options.plugins) {
       require(`prismjs/plugins/line-numbers/prism-${plugin}`)


### PR DESCRIPTION
Hello! Thank you for creating the plugin.

I used it and got an error with unified v10. This is a fix to optimize for unified v10. This makes unified v9 unusable, so a decision needs to be made. Please merge if you like.

**Close issues**

**Please check if the PR fulfills these requirements**

- [x] Have you followed the guidelines in our [Contributing document](https://github.com/Val-istar-Guo/rehype-prism/blob/master/.github/CODE_OF_CONDUCT.md)?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you written or modified docs for your core changes, as applicable?
