### PR TITLE
Fix esm dynamic import

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,7 @@ export interface RehypePrismOptions {
 const rehypePrism: unifiedTypes.Plugin<[RehypePrismOptions?]> = (options?: RehypePrismOptions) => {
   if (options && options.plugins) {
     for (const plugin of options.plugins) {
-      require(`prismjs/plugins/line-numbers/prism-${plugin}`)
+      import(`prismjs/plugins/${plugin}/prism-${plugin}.js`)
     }
   }
 

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -9,7 +9,7 @@ import rehypePrism from '../src/index.js'
 test('rehype prism', t => {
   const processor = unified()
     .use(markdown)
-    .use(rehypePrism)
+    .use(rehypePrism, {plugins: ["toolbar", "copy-to-clipboard"]})
     .use(remark2rehype)
     .use(html)
 


### PR DESCRIPTION
Hello! rehype-prism is an ESM, but the plugin import does not seem to work. So we've made some fixes, including some testing! Now there is no error.

... Well, but most Prism plugins work only in the browser, so even if the import succeeds, it won't work. This is a problem with Prism, though.

**Please check if the PR fulfills these requirements**

- [x] Have you followed the guidelines in our [Contributing document](https://github.com/Val-istar-Guo/rehype-prism/blob/master/.github/CODE_OF_CONDUCT.md)?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you written or modified docs for your core changes, as applicable?
